### PR TITLE
AGPUSH-504 Adding basic snapshot and restore hooks for upgrading the cartridge

### DIFF
--- a/bin/control
+++ b/bin/control
@@ -4,6 +4,7 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 JBOSSAS_BIN_DIR=${OPENSHIFT_AEROGEAR_PUSH_DIR}/bin
 JBOSSAS_PID_FILE=${OPENSHIFT_HOMEDIR}/app-root/runtime/aerogear_push.pid
+JBOSSAS_STANDALONE_DIR=${OPENSHIFT_AEROGEAR_PUSH_DIR}/standalone
 
 source $JBOSSAS_BIN_DIR/util
 
@@ -159,6 +160,40 @@ function threaddump() {
     fi
 }
 
+function pre_snapshot {
+  start
+  echo "$OPENSHIFT_AEROGEAR_PUSH_TOKEN_KEY" > $OPENSHIFT_DATA_DIR/aerogear_push_token_key
+  cp $OPENSHIFT_AEROGEAR_PUSH_DIR/standalone/configuration/standalone.xml $OPENSHIFT_DATA_DIR/standalone.snapshot.xml
+  stop
+}
+
+function post_snapshot {
+  true
+}
+
+function pre_restore {
+  cleanup_dump
+}
+
+function post_restore {
+  if [ -s $OPENSHIFT_DATA_DIR/aerogear_push_token_key ]; then
+    TOKEN_KEY=$(< $OPENSHIFT_DATA_DIR/aerogear_push_token_key)
+    echo $TOKEN_KEY > $OPENSHIFT_AEROGEAR_PUSH_DIR/env/OPENSHIFT_AEROGEAR_PUSH_TOKEN_KEY
+    sed -i "s/<server socket-binding=\"simplepush\"\(.*\) password=\"[^\"]\+\"/<server socket-binding=\"simplepush\"\1 password=\"$TOKEN_KEY\"/" $JBOSSAS_STANDALONE_DIR/configuration/standalone.xml > /dev/null 2>&1
+  fi
+
+  if [ -s $OPENSHIFT_DATA_DIR/standalone.snapshot.xml ]; then
+    cp $OPENSHIFT_DATA_DIR/standalone.snapshot.xml $OPENSHIFT_AEROGEAR_PUSH_DIR/standalone/configuration/standalone_xml_history/snapshot/standalone.snapshot.xml
+  fi
+
+  cleanup_dump
+}
+
+function cleanup_dump {
+  rm -f $OPENSHIFT_DATA_DIR/aerogear_push_token_key
+  rm -f $OPENSHIFT_DATA_DIR/standalone.snapshot.xml
+}
+
 case "$1" in
   start)           start ;;
   stop)            stop ;;
@@ -168,6 +203,10 @@ case "$1" in
   tidy)            tidy ;;
   threaddump)      threaddump ;;
   update-configuration) update-configuration;;
+  pre-snapshot)    pre_snapshot ;;
+  post-snapshot)   post_snapshot ;;
+  pre-restore)     pre_restore ;;
+  post-restore)    post_restore ;;
   *)               exit 0
 esac
 

--- a/metadata/managed_files.yml
+++ b/metadata/managed_files.yml
@@ -1,4 +1,7 @@
 ---
+snapshot_exclusions:
+- ~/aerogear-push/versions
+- ~/aerogear-push/modules
 locked_files:
 - bin/
 - bin/*
@@ -9,7 +12,6 @@ locked_files:
 - env/OPENSHIFT_AEROGEAR_PUSH_LOG_DIR
 - env/OPENSHIFT_AEROGEAR_PUSH_JDK*
 - env/OPENSHIFT_AEROGEAR_PUSH_VERSION
-- env/OPENSHIFT_AEROGEAR_PUSH_TOKEN_KEY
 - env/M2_HOME
 - standalone/deployments/*
 - usr/modules/org/


### PR DESCRIPTION
To test it:

1) Create an instance

```
rhc app create --no-git <APP> https://cartreflect-claytondev.rhcloud.com/reflect?github=fjuma/openshift-origin-cartridge-aerogear-push
```

2) Log into the admin console, set your new password, create push applications, create variants, and send some push notifications.

3) Create a snapshot, then delete the instance, then create a new instance and restore it from the snapshot.

```
rhc snapshot save <APP>
rhc app delete <APP>
rhc app create --no-git <APP> https://cartreflect-claytondev.rhcloud.com/reflect?github=fjuma/openshift-origin-cartridge-aerogear-push
rhc snapshot restore <APP> -f /PATH/TO/<APP>.tar.gz
```

4) You should now be able to log into the admin console with the same password you previously set, see existing push applications and variants, and send push notifications.

Note: An 0.11.0 instance is being created in step 1) and step 3) just to simplify testing since we don't have MySQL-specific hooks implemented yet for model changes.
