### PR TITLE
Use double quote instead of single ones

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -41,5 +41,5 @@ client_result "Aerogear Push Server added.  Please make note of these default cr
 client_result ""
 client_result "           User: admin"
 client_result "       Password: 123"
-client_result ' Connection URL: https://$OPENSHIFT_APP_DNS/ag-push'
+client_result " Connection URL: https://$OPENSHIFT_APP_DNS/ag-push"
 client_result ""


### PR DESCRIPTION
Correct the output from:
  Connection URL: https://$OPENSHIFT_APP_DNS/ag-push
to
  Connection URL: https://appname-domainname.rhcloud.com/ag-push
